### PR TITLE
Update 50unattended-upgrades.erb to new package defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ name: ci
 jobs:
   lint-unit:
     uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
+    permissions:
+      actions: write
+      checks: write
+      pull-requests: write
+      statuses: write
+      issues: write
 
   integration:
     needs: 'lint-unit'
@@ -22,6 +28,7 @@ jobs:
           - 'debian-11'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
+          - 'ubuntu-2204'
         suite:
           - 'default'
           - 'cacher'
@@ -38,7 +45,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Dokken

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ This file is used to list changes made in each version of the apt cookbook.
 
 ## Unreleased
 
+- Update `50unattended-upgrades` to package defaults
+- Add testing for Ubuntu 22.04
+- CI updates
+
 ## 7.4.3 - *2022-12-05*
 
-Standardise files with files in sous-chefs/repo-management
-
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 7.4.2 - *2022-02-02*
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -36,3 +36,8 @@ platforms:
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
+
+  - name: ubuntu-22.04
+    driver:
+      image: dokken/ubuntu-22.04
+      pid_one_command: /bin/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,6 +17,7 @@ platforms:
   - name: debian-11
   - name: ubuntu-18.04
   - name: ubuntu-20.04
+  - name: ubuntu-22.04
   - name: ubuntu-16.04-chef-13.3
     driver_config:
       box: bento/ubuntu-16.04

--- a/templates/50unattended-upgrades.erb
+++ b/templates/50unattended-upgrades.erb
@@ -15,7 +15,7 @@ Unattended-Upgrade::Origins-Pattern {
 };
 
 <% end -%>
-// List of packages to not update
+// Python regular expressions, matching packages to exclude from upgrading
 Unattended-Upgrade::Package-Blacklist {
 <% unless node['apt']['unattended_upgrades']['package_blacklist'].empty? -%>
 <% node['apt']['unattended_upgrades']['package_blacklist'].each do |package| -%>
@@ -31,21 +31,27 @@ Unattended-Upgrade::Package-Blacklist {
 Unattended-Upgrade::AutoFixInterruptedDpkg "<%= node['apt']['unattended_upgrades']['auto_fix_interrupted_dpkg'] ? 'true' : 'false' %>";
 
 // Split the upgrade into the smallest possible chunks so that
-// they can be interrupted with SIGUSR1. This makes the upgrade
+// they can be interrupted with SIGTERM. This makes the upgrade
 // a bit slower but it has the benefit that shutdown while a upgrade
 // is running is possible (with a small delay)
 Unattended-Upgrade::MinimalSteps "<%= node['apt']['unattended_upgrades']['minimal_steps'] ? 'true' : 'false' %>";
 
-// Install all unattended-upgrades when the machine is shuting down
-// instead of doing it in the background while the machine is running
-// This will (obviously) make shutdown slower
+// Install all updates when the machine is shutting down
+// instead of doing it in the background while the machine is running.
+// This will (obviously) make shutdown slower.
+// Unattended-upgrades increases logind's InhibitDelayMaxSec to 30s.
+// This allows more time for unattended-upgrades to shut down gracefully
+// or even install a few packages in InstallOnShutdown mode, but is still a
+// big step back from the 30 minutes allowed for InstallOnShutdown previously.
+// Users enabling InstallOnShutdown mode are advised to increase
+// InhibitDelayMaxSec even further, possibly to 30 minutes.
 Unattended-Upgrade::InstallOnShutdown "<%= node['apt']['unattended_upgrades']['install_on_shutdown'] ? 'true' : 'false' %>";
 
 <% if node['apt']['unattended_upgrades']['mail'] -%>
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you
 // have a working mail setup on your system. A package that provides
-// 'mailx' must be installed.
+// 'mailx' must be installed. E.g. "user@example.com"
 Unattended-Upgrade::Mail "<%= node['apt']['unattended_upgrades']['mail'] %>";
 <% end -%>
 
@@ -55,21 +61,36 @@ Unattended-Upgrade::Mail "<%= node['apt']['unattended_upgrades']['mail'] %>";
 Unattended-Upgrade::Sender "<%= node['apt']['unattended_upgrades']['sender'] %>";
 <% end -%>
 
-// Set this value to "true" to get emails only on errors. Default
-// is to always send a mail if Unattended-Upgrade::Mail is set
+// Set this value to one of:
+//    "always", "only-on-error" or "on-change"
+// If this is not set, then any legacy MailOnlyOnError (boolean) value
+// is used to chose between "only-on-error" and "on-change"
+//Unattended-Upgrade::MailReport "on-change";
 Unattended-Upgrade::MailOnlyOnError "<%= node['apt']['unattended_upgrades']['mail_only_on_error'] ? 'true' : 'false' %>";
 
-// Do automatic removal of new unused dependencies after the upgrade
+// Remove unused automatically installed kernel-related packages
+// (kernel images, kernel headers and kernel version locked tools).
+//Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+
+// Do automatic removal of newly unused dependencies after the upgrade
+//Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
+
+// Do automatic removal of unused packages after the upgrade
 // (equivalent to apt-get autoremove)
 Unattended-Upgrade::Remove-Unused-Dependencies "<%= node['apt']['unattended_upgrades']['remove_unused_dependencies'] ? 'true' : 'false' %>";
 
-// Automatically reboot *WITHOUT CONFIRMATION* if a
-// the file /var/run/reboot-required is found after the upgrade
+// Automatically reboot *WITHOUT CONFIRMATION* if
+//  the file /var/run/reboot-required is found after the upgrade
 Unattended-Upgrade::Automatic-Reboot "<%= node['apt']['unattended_upgrades']['automatic_reboot'] ? 'true' : 'false' %>";
 
 <% if node['apt']['unattended_upgrades']['automatic_reboot'] -%>
+// Automatically reboot even if there are users currently logged in
+// when Unattended-Upgrade::Automatic-Reboot is set to true
+//Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
+
 // If automatic reboot is enabled and needed, reboot at the specific
-// time instead of immediately. Default is "now"
+// time instead of immediately
+//  Default: "now"
 Unattended-Upgrade::Automatic-Reboot-Time "<%= node['apt']['unattended_upgrades']['automatic_reboot_time'] %>";
 <% end %>
 
@@ -84,17 +105,9 @@ Acquire::http::Dl-Limit "<%= node['apt']['unattended_upgrades']['dl_limit'] %>";
 Unattended-Upgrade::SyslogEnable "<%= node['apt']['unattended_upgrades']['syslog_enable'] ? 'true' : 'false' %>";
 
 // Specify syslog facility. Default is daemon
-Unattended-Upgrade::SyslogFacility "<%= node['apt']['unattended_upgrades']['syslog_facility'] %>";
+Unattended-Upgrade::SyslogFacility "<%= node['apt']['unattended_upgrades']['syslog_facility'] %>"
 
-// specify any dpkg options you want to run
-// for example if you wanted to upgrade and use
-// the installed version of config files when
-// resolving conflicts during an upgrade you
-// typically need:
-// Dpkg::Options {
-//   "--force-confdef";
-//   "--force-confold";
-//};
+
 <% unless node['apt']['unattended_upgrades']['dpkg_options'].empty? -%>
 Dpkg::Options {
 <% node['apt']['unattended_upgrades']['dpkg_options'].each do |option|%>
@@ -102,3 +115,18 @@ Dpkg::Options {
 <% end -%>
 };
 <% end -%>
+
+// Download and install upgrades only on AC power
+// (i.e. skip or gracefully stop updates on battery)
+// Unattended-Upgrade::OnlyOnACPower "true";
+
+// Download and install upgrades only on non-metered connection
+// (i.e. skip or gracefully stop updates on a metered connection)
+// Unattended-Upgrade::Skip-Updates-On-Metered-Connections "true";
+
+// Verbose logging
+// Unattended-Upgrade::Verbose "false";
+
+// Print debugging information both in unattended-upgrades and
+// in unattended-upgrade-shutdown
+// Unattended-Upgrade::Debug "false";

--- a/templates/50unattended-upgrades.erb
+++ b/templates/50unattended-upgrades.erb
@@ -105,7 +105,7 @@ Acquire::http::Dl-Limit "<%= node['apt']['unattended_upgrades']['dl_limit'] %>";
 Unattended-Upgrade::SyslogEnable "<%= node['apt']['unattended_upgrades']['syslog_enable'] ? 'true' : 'false' %>";
 
 // Specify syslog facility. Default is daemon
-Unattended-Upgrade::SyslogFacility "<%= node['apt']['unattended_upgrades']['syslog_facility'] %>"
+Unattended-Upgrade::SyslogFacility "<%= node['apt']['unattended_upgrades']['syslog_facility'] %>";
 
 
 <% unless node['apt']['unattended_upgrades']['dpkg_options'].empty? -%>


### PR DESCRIPTION
### Description

It updates 50unattended-upgrades to the new package config

See:
https://raw.githubusercontent.com/mvo5/unattended-upgrades/df3b8cf50d25195b208b6c8f748c5034908478cd/data/50unattended-upgrades.Debian

The Unattended-Upgrade::Sender setting is no longer present in the new
package config but it has not been removed.

Unattended-Upgrade::MailReport is a new setting. It will fallback to the
legacy Unattended-Upgrade::MailOnlyOnError.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
